### PR TITLE
Fix malformed XUL exception

### DIFF
--- a/profile/chrome/utils/boot.jsm
+++ b/profile/chrome/utils/boot.jsm
@@ -713,6 +713,22 @@ UserChrome_js.prototype = {
       // Add simple script menu to menubar tools popup
       const menu = document.querySelector("#menu_openDownloads");
       if(isWindow && menu){
+        function escapeXUL(markup) {
+          return markup.replace(/[<>&'"]/g, (char) => {
+            switch (char) {
+              case `<`:
+                return "&lt;";
+              case `>`:
+                return "&gt;";
+              case `&`:
+                return "&amp;";
+              case `'`:
+                return "&apos;";
+              case '"':
+                return "&quot;";
+            }
+          });
+        }
         let menuFragment = window.MozXULElement.parseXULToFragment(`
           <menu id="userScriptsMenu" label="userScripts">
             <menupopup id="menuUserScriptsPopup" onpopupshown="_ucUtils.updateMenuStatus(this)">
@@ -726,8 +742,8 @@ UserChrome_js.prototype = {
           itemsFragment.append(
             window.MozXULElement.parseXULToFragment(`
               <menuitem type="checkbox"
-                        label="${script.name || script.filename}"
-                        filename="${script.filename}"
+                        label="${escapeXUL(script.name || script.filename)}"
+                        filename="${escapeXUL(script.filename)}"
                         checked="true"
                         oncommand="_ucUtils.toggleScript(this)">
               </menuitem>


### PR DESCRIPTION
Since the userScripts menu is built with parseXULToFragment now, there's an unhandled error when loading a script whose name or filename contains an XML special character, which prevents the menu from being built.
Resolved by replacing the characters with their escaped varieties. Sorry, github automatically adds a newline for some reason