### PR TITLE
Update TypeScript types

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -423,7 +423,18 @@ Note that some CSS features may not be available for file:// uri styles. However
 
 For pre 0.10.0 definitions you can check separate file available at [uc_utils_old.md](./uc_utils_old.md).
 
-TypeScript types are also available as a private npm package in the [types](./types) directory.
+TypeScript types are also available as a private npm package in the [types](./types) directory. To use them with `chrome://` imports - put the following in your tsconfig.json:
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "chrome://userchromejs/content/uc_api.sys.mjs": [
+        "./node_modules/@types/fx-autoconfig/index.d.ts"
+      ]
+    }
+  }
+}
+```
 
 Helpers are available as a namespace object - the whole namespace can be imported to module scripts as follows:
 

--- a/readme.md
+++ b/readme.md
@@ -423,19 +423,19 @@ Note that some CSS features may not be available for file:// uri styles. However
 
 For pre 0.10.0 definitions you can check separate file available at [uc_utils_old.md](./uc_utils_old.md).
 
-TypeScript types available as a private npm package in the [types](./types) directory.
+TypeScript types are also available as a private npm package in the [types](./types) directory.
 
 Helpers are available as a namespace object - the whole namespace can be imported to module scripts as follows:
 
 ```js
-import * from "chrome://userchromejs/content/uc_api.sys.mjs";
+import * as UC_API from "chrome://userchromejs/content/uc_api.sys.mjs";
 ```
 The same namespace is also defined on window objects as `UC_API` symbol that can be used in window scoped scripts.
 
 Or you can import individual namespaces like this:
 
 ```js
-import FileSystem from "chrome://userchromejs/content/uc_api.sys.mjs";
+import { FileSystem } from "chrome://userchromejs/content/uc_api.sys.mjs";
 ```
 
 Helpers divided into separate namespaces:

--- a/types/api/FileSystem.d.ts
+++ b/types/api/FileSystem.d.ts
@@ -72,17 +72,13 @@ interface UC_FileSystem {
 	chromeDir(): FileSystemResult;
 	getEntry(fileName: string): FileSystemResult;
 	readFile(fileName: string): Promise<FileSystemResult>;
-
-	/**
-	 * @param some any = nsIFile
-	 */
-	readFileSync(some: string | any): FileSystemResult;
+	readFileSync(some: string | nsIFile): FileSystemResult;
 
 	/**
 	 * Asynchronously try to read a file and parse it as json.
 	 * If file can't be parsed then returns `null`.
 	 */
-	readJSON(fileName: string): Promise<any | null>;
+	readJSON(fileName: string): Promise<object | null>;
 
 	/**
 	 * Write the content into file *as UTF8*.
@@ -96,7 +92,7 @@ interface UC_FileSystem {
 	 * @param content
 	 * @param options currently only used to pass a filename for temp file.
 	 * By default it is derived from fileName.
-	 * @returns the promise that resolves with number of written bytes.
+	 * @returns the number of written bytes.
 	 *
 	 * @note Currently this method replaces the existing file if one exists.
 	 */

--- a/types/api/Hotkeys.d.ts
+++ b/types/api/Hotkeys.d.ts
@@ -19,7 +19,7 @@ interface Hotkey {
 	matchingSelector: string;
 	trigger: any;
 	attachToWindow(window: Window, opt): Promise<void>;
-	autoAttach(opt?): void;
+	autoAttach(opt?): Promise<void>;
 	restoreOriginalKey(window: Window): void;
 	suppressOriginalKey(window: Window): void;
 }

--- a/types/api/Hotkeys.d.ts
+++ b/types/api/Hotkeys.d.ts
@@ -4,7 +4,7 @@ interface HotkeyDetails {
 	key: string;
 
 	/**
-	 * If command is a function then a new <command> element will be created
+	 * If command is a function then a new `<command>` element will be created
 	 * for it with an id attribute derived from the specified id.
 	 *
 	 * If command is a string then the hotkey will simply invoke a command
@@ -14,12 +14,16 @@ interface HotkeyDetails {
 	command: ((window: Window, commandEvent: any) => void) | string;
 }
 
+interface HotkeyOptions {
+	suppressOriginal: boolean;
+}
+
 interface Hotkey {
 	command: any;
 	matchingSelector: string;
 	trigger: any;
-	attachToWindow(window: Window, opt): Promise<void>;
-	autoAttach(opt?): Promise<void>;
+	attachToWindow(window: Window, opts?: HotkeyOptions): Promise<void>;
+	autoAttach(opts?: HotkeyOptions): Promise<void>;
 	restoreOriginalKey(window: Window): void;
 	suppressOriginalKey(window: Window): void;
 }

--- a/types/api/Prefs.d.ts
+++ b/types/api/Prefs.d.ts
@@ -11,7 +11,7 @@ interface Pref {
 
 interface PrefListener {
 	// copied from lib.gecko.xpcom.d.ts
-	observer(aDomain: string, aObserver: any, aHoldWeak?: boolean): void;
+	observer(aDomain: string, aObserver: nsIObserver, aHoldWeak?: boolean): void;
 	pref: string;
 }
 

--- a/types/api/Scripts.d.ts
+++ b/types/api/Scripts.d.ts
@@ -91,11 +91,10 @@ interface Scripts {
 	): ScriptInfo;
 
 	/**
-	 * @param fileName If element, reads a `filename` attribute from the element
-	 * and uses that. Toggles the specified script, note that browser restart is
-	 * required for changes to take effect.
+	 * Toggles the specified script, note that browser restart is required for
+	 * changes to take effect.
 	 */
-	toggleScript(fileName: string | Element): ScriptInfo;
+	toggleScript(fileName: string): ScriptInfo;
 
 	/**
 	 * @param name Relative to resources folder, but you can use `../` prefix

--- a/types/api/Scripts.d.ts
+++ b/types/api/Scripts.d.ts
@@ -1,8 +1,7 @@
+type StyleSheetMode = "agent" | "author";
+
 interface ScriptInfo {
-	/**
-	 * @returns nsIFile
-	 */
-	asFile(): any;
+	asFile(): nsIFile;
 	author: string | undefined;
 	charset: string | undefined;
 	chromeURI: string | undefined;
@@ -27,7 +26,7 @@ interface ScriptInfo {
 	optionsURL: string | undefined;
 	referenceURI: string;
 	regex: RegExp | null;
-	styleSheetMode: any | null;
+	styleSheetMode: StyleSheetMode | null;
 	type: string;
 	updateURL: string | undefined;
 	useFileURI: boolean;
@@ -111,5 +110,5 @@ interface Scripts {
 	 * might be that reload of imported stylesheets does not take effect until a
 	 * new window is created.
 	 */
-	reloadStyleSheet(name?: string, sheet_mode?: "agent" | "author"): boolean;
+	reloadStyleSheet(name?: string, sheet_mode?: StyleSheetMode): boolean;
 }

--- a/types/api/Utils.d.ts
+++ b/types/api/Utils.d.ts
@@ -67,7 +67,7 @@ interface Utils {
 	createElement(
 		document: Document,
 		tagname: string,
-		attributes: any,
+		attributes: Record<string, string>,
 		isHTML: boolean,
 	): Element;
 
@@ -83,7 +83,7 @@ interface Utils {
 	 * in multiple Firefox windows then the first one should
 	 * succeed, but successive calls should throw an Error.
 	 *
-	 * @returns this class https://searchfox.org/mozilla-central/source/browser/components/customizableui/CustomizableUI.sys.mjs#5491
+	 * @returns this class https://searchfox.org/mozilla-central/source/browser/components/customizableui/CustomizableUI.sys.mjs#5991 (or `WidgetGroupWrapper` if outdated).
 	 */
 	createWidget(details: WidgetDetails): WidgetWrapper;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,4 +20,15 @@ declare global {
 	};
 }
 
+declare module "chrome://userchromejs/content/uc_api.sys.mjs" {
+	export const FileSystem: UC_FileSystem;
+	export const Hotkeys: Hotkeys;
+	export const Notifications: Notifications;
+	export const Prefs: Prefs;
+	export const Runtime: Runtime;
+	export const Scripts: Scripts;
+	export const Utils: Utils;
+	export const Windows: Windows;
+}
+
 export type {};


### PR DESCRIPTION
I figured out how to use types with custom URIs, so figured I'd update types as well
![image](https://github.com/user-attachments/assets/f21fe73c-595b-4ba2-b0d4-d563249f119d)
also `nsIFile`, `nsIObserver`, etc. will be `any` if they're not found, so take advantage of that, too.